### PR TITLE
fix JSON deserialisation problem.

### DIFF
--- a/liboidcagent/liboidcagent.py
+++ b/liboidcagent/liboidcagent.py
@@ -95,7 +95,7 @@ def _communicate_with_sock(request):
         if len(part) < 4096:
             break
 
-    data = json.loads(res)
+    data = json.loads(res.decode("utf-8"))
     if 'error' in data:
         error = data['error']
         raise OidcAgentError(error)


### PR DESCRIPTION
This is reported with the following stacktrace

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/paul/.local/lib/python3.5/site-packages/liboidcagent/liboidcagent.py", line 38, in get_access_token
    scope, audience)[0]
  File "/home/paul/.local/lib/python3.5/site-packages/liboidcagent/liboidcagent.py", line 28, in get_token_response
    application_hint, scope, audience))
  File "/home/paul/.local/lib/python3.5/site-packages/liboidcagent/liboidcagent.py", line 98, in _communicate_with_sock
    data = json.loads(res)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

Closes: indigo-dc/liboidc-agent-py#4